### PR TITLE
Add support for mail address, etc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 build/
 dist/
 
+# pyenv
+.python-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: python
+python:
+  - "3.8"
+script:
+  - pytest

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -5,7 +5,7 @@ from jupyterhub.auth import Authenticator
 from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join
 from tornado import gen, web
-from traitlets import Unicode
+from traitlets import Unicode, Bool
 from .utils import normalize_quoted_printable
 
 

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -83,6 +83,14 @@ class RemoteUserLocalAuthenticator(LocalAuthenticator):
         help="""HTTP header to inspect for the authenticated username.""")
 
     """
+    Accept the email address of authenticated user from the X_AUTH_MAIL_ADDRESS HTTP header.
+    """
+    mail_header_name = Unicode(
+        default_value='X_AUTH_MAIL_ADDRESS',
+        config=True,
+        help="""HTTP header to inspect for the email address of authenticated user.""")
+
+    """
     Custom Logout URL (e.g. Shibboleth.sso/Logout)
     """
     custom_logout_url = Unicode(

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -6,6 +6,7 @@ from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join
 from tornado import gen, web
 from traitlets import Unicode
+from .utils import normalize_quoted_printable
 
 
 class RemoteUserLoginHandler(BaseHandler):
@@ -15,6 +16,8 @@ class RemoteUserLoginHandler(BaseHandler):
         remote_user = self.request.headers.get(header_name, "")
         if remote_user == "":
             raise web.HTTPError(401)
+        if self.authenticator.use_quoted_printable_normalization:
+            remote_user = normalize_quoted_printable(remote_user)
 
         user = self.user_from_username(remote_user)
         self.set_login_cookie(user)
@@ -47,6 +50,14 @@ class RemoteUserAuthenticator(Authenticator):
         default_value='X_AUTH_MAIL_ADDRESS',
         config=True,
         help="""HTTP header to inspect for the email address of authenticated user.""")
+
+    """
+    Whether to apply quoted_printable_normalization to REMOTE_USER header.
+    """
+    use_quoted_printable_normalization = Bool(
+        default_value=True,
+        config=True,
+        help="""Whether to apply quoted_printable_normalization to REMOTE_USER header""")
 
     """
     Custom Logout URL (e.g. Shibboleth.sso/Logout)
@@ -89,6 +100,14 @@ class RemoteUserLocalAuthenticator(LocalAuthenticator):
         default_value='X_AUTH_MAIL_ADDRESS',
         config=True,
         help="""HTTP header to inspect for the email address of authenticated user.""")
+
+    """
+    Whether to apply quoted_printable_normalization to REMOTE_USER header.
+    """
+    use_quoted_printable_normalization = Bool(
+        default_value=True,
+        config=True,
+        help="""Whether to apply quoted_printable_normalization to REMOTE_USER header""")
 
     """
     Custom Logout URL (e.g. Shibboleth.sso/Logout)

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -31,10 +31,23 @@ class RemoteUserAuthenticator(Authenticator):
         config=True,
         help="""HTTP header to inspect for the authenticated username.""")
 
+    """
+    Custom Logout URL (e.g. Shibboleth.sso/Logout)
+    """
+    custom_logout_url = Unicode(
+        default_value='',
+        config=True,
+        help="""The URL for Logout button""")
+
     def get_handlers(self, app):
         return [
             (r'/login', RemoteUserLoginHandler),
         ]
+
+    def logout_url(self, base_url):
+        if len(self.custom_logout_url):
+            return self.custom_logout_url
+        return super(RemoteUserAuthenticator, self).logout_url(base_url)
 
     @gen.coroutine
     def authenticate(self, *args):
@@ -52,10 +65,23 @@ class RemoteUserLocalAuthenticator(LocalAuthenticator):
         config=True,
         help="""HTTP header to inspect for the authenticated username.""")
 
+    """
+    Custom Logout URL (e.g. Shibboleth.sso/Logout)
+    """
+    custom_logout_url = Unicode(
+        default_value='',
+        config=True,
+        help="""The URL for Logout button""")
+
     def get_handlers(self, app):
         return [
             (r'/login', RemoteUserLoginHandler),
         ]
+
+    def logout_url(self, base_url):
+        if len(self.custom_logout_url):
+            return self.custom_logout_url
+        return super(RemoteUserLocalAuthenticator, self).logout_url(base_url)
 
     @gen.coroutine
     def authenticate(self, *args):

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -22,7 +22,7 @@ class RemoteUserLoginHandler(BaseHandler):
             mail_header_name = self.authenticator.mail_header_name
             mail_address = self.request.headers.get(mail_header_name, "")
             self.log.debug("E-mail address of user, current={}, set={}".format(user.mail_address, mail_address))
-            if mail_address and not user.mail_address:
+            if mail_address:
                 user.mail_address = mail_address
                 self.db.commit()
         else:

--- a/jhub_remote_user_authenticator/tests/test_utils.py
+++ b/jhub_remote_user_authenticator/tests/test_utils.py
@@ -2,11 +2,15 @@ from jhub_remote_user_authenticator import utils
 
 
 def test_quoted_printable_normalization_str():
-    assert utils.normalize_quoted_printable('test@test') == 'test@test'
+    assert utils.normalize_quoted_printable('test@test.jp') == 'test@test.jp'
+    assert utils.normalize_quoted_printable('test-@test') == 'test-@test'
     assert utils.normalize_quoted_printable('entity://test@test') == 'entity:=2F=2Ftest@test'
     assert utils.normalize_quoted_printable('entity://test漢字@test') == 'entity:=2F=2Ftest=E6=BC=A2=E5=AD=97@test'
     assert utils.normalize_quoted_printable('test.sample@test/') == 'test.sample@test=2F'
+    assert utils.normalize_quoted_printable('test.sample!sample@test/') == 'test.sample=21sample@test=2F'
 
 def test_quoted_printable_normalization_bytes():
-    assert utils.normalize_quoted_printable(b'test@test') == 'test@test'
+    assert utils.normalize_quoted_printable(b'test@test.jp') == 'test@test.jp'
+    assert utils.normalize_quoted_printable(b'test-@test') == 'test-@test'
     assert utils.normalize_quoted_printable(b'entity://test@test') == 'entity:=2F=2Ftest@test'
+    assert utils.normalize_quoted_printable(b'entity://test!sample@test') == 'entity:=2F=2Ftest=21sample@test'

--- a/jhub_remote_user_authenticator/tests/test_utils.py
+++ b/jhub_remote_user_authenticator/tests/test_utils.py
@@ -1,0 +1,12 @@
+from jhub_remote_user_authenticator import utils
+
+
+def test_quoted_printable_normalization_str():
+    assert utils.normalize_quoted_printable('test@test') == 'test@test'
+    assert utils.normalize_quoted_printable('entity://test@test') == 'entity:=2F=2Ftest@test'
+    assert utils.normalize_quoted_printable('entity://test漢字@test') == 'entity:=2F=2Ftest=E6=BC=A2=E5=AD=97@test'
+    assert utils.normalize_quoted_printable('test.sample@test/') == 'test.sample@test=2F'
+
+def test_quoted_printable_normalization_bytes():
+    assert utils.normalize_quoted_printable(b'test@test') == 'test@test'
+    assert utils.normalize_quoted_printable(b'entity://test@test') == 'entity:=2F=2Ftest@test'

--- a/jhub_remote_user_authenticator/utils.py
+++ b/jhub_remote_user_authenticator/utils.py
@@ -3,8 +3,7 @@ import string
 
 def normalize_quoted_printable(srcstr):
     unreserved  = string.ascii_letters + string.digits + '-._~'
-    sub_delims = '!$&\'()*+,;='
-    pchar = (unreserved + sub_delims + ':@').encode('latin-1')
+    pchar = (unreserved + ':@').encode('latin-1')
     if isinstance(srcstr, str):
         src = srcstr.encode('utf8')
     else:

--- a/jhub_remote_user_authenticator/utils.py
+++ b/jhub_remote_user_authenticator/utils.py
@@ -1,0 +1,19 @@
+import string
+
+
+def normalize_quoted_printable(srcstr):
+    unreserved  = string.ascii_letters + string.digits + '-._~'
+    sub_delims = '!$&\'()*+,;='
+    pchar = (unreserved + sub_delims + ':@').encode('latin-1')
+    if isinstance(srcstr, str):
+        src = srcstr.encode('utf8')
+    else:
+        src = srcstr
+
+    encoded = b''
+    for index in range(len(src)):
+        if src[index] in pchar:
+            encoded += src[index:index + 1]
+            continue
+        encoded += '={0:02x}'.format(src[index]).upper().encode('latin-1')
+    return encoded.decode('latin-1')


### PR DESCRIPTION
Shibbolethとの連携に関する変更です。

- logout用のURLをカスタマイズ可能に設定項目を追加
- mail addressを受け取るためのヘッダ設定を追加
- mail addressの受け取り処理を実装
- REMOTE_USERヘッダで渡される識別子(ePPN)のQuoted Printable-like Encodingの実装