### PR TITLE
Organization & Mail Validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@ language: python
 python:
   - "3.8"
 script:
+  - pip install jupyterhub
   - pytest

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -95,6 +95,9 @@ class RemoteUserAuthenticator(Authenticator):
         if self.allow_any_organizations:
             return True
         self.log.debug("Headers: {}".format(list(headers.keys())))
+        self.log.debug("Eppn: {}".format(headers.get('Eppn', '(None)')))
+        self.log.debug("Affiliation: {}".format(headers.get('Affiliation', '(None)')))
+        self.log.debug("Mail: {}".format(headers.get('Mail', '(None)')))
         return check_valid_organization(headers)
 
 
@@ -159,4 +162,7 @@ class RemoteUserLocalAuthenticator(LocalAuthenticator):
         if self.allow_any_organizations:
             return True
         self.log.debug("Headers: {}".format(list(headers.keys())))
+        self.log.debug("Eppn: {}".format(headers.get('Eppn', '(None)')))
+        self.log.debug("Affiliation: {}".format(headers.get('Affiliation', '(None)')))
+        self.log.debug("Mail: {}".format(headers.get('Mail', '(None)')))
         return check_valid_organization(headers)

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -94,7 +94,7 @@ class RemoteUserAuthenticator(Authenticator):
     def check_valid_organization(self, headers):
         if self.allow_any_organizations:
             return True
-        self.log.debug("Headers: {}".format(repr(headers)))
+        self.log.debug("Headers: {}".format(list(headers.keys())))
         return check_valid_organization(headers)
 
 
@@ -158,5 +158,5 @@ class RemoteUserLocalAuthenticator(LocalAuthenticator):
     def check_valid_organization(self, headers):
         if self.allow_any_organizations:
             return True
-        self.log.debug("Headers: {}".format(repr(headers)))
+        self.log.debug("Headers: {}".format(list(headers.keys())))
         return check_valid_organization(headers)

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -6,7 +6,18 @@ from jupyterhub.auth import LocalAuthenticator
 from jupyterhub.utils import url_path_join
 from tornado import gen, web
 from traitlets import Unicode, Bool
-from .utils import normalize_quoted_printable, check_valid_organization
+from .utils import normalize_quoted_printable
+
+
+def check_valid_organization(headers):
+    eppn = headers.get('Eppn', None)
+    mail = headers.get('Mail', None)
+    if eppn is None:
+        return False
+    if eppn.endswith('@openidp.nii.ac.jp'):
+        if mail is None or not mail.endswith('.ac.jp'):
+            return False
+    return True
 
 
 class RemoteUserLoginHandler(BaseHandler):

--- a/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
+++ b/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
@@ -7,7 +7,35 @@ from jhub_remote_user_authenticator import remote_user_auth
                           remote_user_auth.RemoteUserLocalAuthenticator])
 def test_valid_organization(authclass):
     auth = authclass()
-    assert auth.check_valid_organization({})
+    assert not auth.check_valid_organization({})
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.co.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.ac.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'test@test-org.ac.jp',
+    })
 
-    auth.allow_any_organizations = False
+    auth.allow_any_organizations = True
     assert auth.check_valid_organization({})
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.co.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.ac.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'test@test-org.ac.jp',
+    })

--- a/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
+++ b/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
@@ -1,0 +1,13 @@
+import pytest
+from jhub_remote_user_authenticator import remote_user_auth
+
+
+@pytest.mark.parametrize('authclass',
+                         [remote_user_auth.RemoteUserAuthenticator,
+                          remote_user_auth.RemoteUserLocalAuthenticator])
+def test_valid_organization(authclass):
+    auth = authclass()
+    assert auth.check_valid_organization({})
+
+    auth.allow_any_organizations = False
+    assert auth.check_valid_organization({})

--- a/jhub_remote_user_authenticator/utils.py
+++ b/jhub_remote_user_authenticator/utils.py
@@ -1,9 +1,6 @@
 import string
 
 
-def check_valid_organization(headers):
-    return True
-
 def normalize_quoted_printable(srcstr):
     unreserved  = string.ascii_letters + string.digits + '-._~'
     pchar = (unreserved + ':@').encode('latin-1')

--- a/jhub_remote_user_authenticator/utils.py
+++ b/jhub_remote_user_authenticator/utils.py
@@ -1,6 +1,9 @@
 import string
 
 
+def check_valid_organization(headers):
+    return True
+
 def normalize_quoted_printable(srcstr):
     unreserved  = string.ascii_letters + string.digits + '-._~'
     pchar = (unreserved + ':@').encode('latin-1')


### PR DESCRIPTION
ログイン時の認証IdPとメールアドレスによる検証処理を実装しました。

* 認証されたIdPはeppnから判定しています(Organizationの属性送出宣言がなくてもチェック可能なため)
* Authenticatorの設定 allow_any_organizations をTrueにすることで、この検証処理をスキップすることができます