### PR TITLE
Add .go.jp to allowed domain

### DIFF
--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -1,5 +1,6 @@
 
 import os
+import re
 from jupyterhub.handlers import BaseHandler
 from jupyterhub.auth import Authenticator
 from jupyterhub.auth import LocalAuthenticator
@@ -15,7 +16,7 @@ def check_valid_organization(headers):
     if eppn is None:
         return False
     if eppn.endswith('@openidp.nii.ac.jp'):
-        if mail is None or not mail.endswith('.ac.jp'):
+        if mail is None or not re.match(r'^.*\.(ac|go)\.jp$', mail):
             return False
     return True
 

--- a/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
+++ b/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
@@ -15,12 +15,31 @@ def test_valid_organization(authclass):
         'Eppn': 'testtest@openidp.nii.ac.jp',
         'Mail': 'test@test-org.co.jp',
     })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.com',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@go.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@ac.jp',
+    })
     assert auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
         'Mail': 'test@test-org.ac.jp',
     })
     assert auth.check_valid_organization({
         'Eppn': 'test@test-org.ac.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.go.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'test@test-org.go.jp',
     })
 
     auth.allow_any_organizations = True
@@ -34,8 +53,27 @@ def test_valid_organization(authclass):
     })
     assert auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.com',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@go.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@ac.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
         'Mail': 'test@test-org.ac.jp',
     })
     assert auth.check_valid_organization({
         'Eppn': 'test@test-org.ac.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.go.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'test@test-org.go.jp',
     })


### PR DESCRIPTION
ログイン時のOpenIdP メールアドレスのドメインチェックにて、.go.jpを許可するようにしました。