### PR TITLE
Add .waseda.jp to allowed domain

### DIFF
--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -17,7 +17,7 @@ def check_valid_organization(headers):
         return False
     if eppn.endswith('@openidp.nii.ac.jp'):
         if mail is None or not (re.match(r'^.*\.(ac|go)\.jp$', mail) or
-           re.match(r'^.*\.waseda\.jp$', mail)):
+           re.match(r'^.*\@(.+\.)?waseda\.jp$', mail)):
             return False
     return True
 

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -16,7 +16,8 @@ def check_valid_organization(headers):
     if eppn is None:
         return False
     if eppn.endswith('@openidp.nii.ac.jp'):
-        if mail is None or not re.match(r'^.*\.(ac|go)\.jp$', mail):
+        if mail is None or not (re.match(r'^.*\.(ac|go)\.jp$', mail) or
+           re.match(r'^.*\.waseda\.jp$', mail)):
             return False
     return True
 

--- a/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
+++ b/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
@@ -41,6 +41,10 @@ def test_valid_organization(authclass):
     assert auth.check_valid_organization({
         'Eppn': 'test@test-org.go.jp',
     })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test.waseda.jp',
+    })
 
     auth.allow_any_organizations = True
     assert auth.check_valid_organization({})
@@ -76,4 +80,8 @@ def test_valid_organization(authclass):
     })
     assert auth.check_valid_organization({
         'Eppn': 'test@test-org.go.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test.waseda.jp',
     })

--- a/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
+++ b/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
@@ -43,6 +43,10 @@ def test_valid_organization(authclass):
     })
     assert auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@waseda.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
         'Mail': 'test@test.waseda.jp',
     })
 
@@ -80,6 +84,10 @@ def test_valid_organization(authclass):
     })
     assert auth.check_valid_organization({
         'Eppn': 'test@test-org.go.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@waseda.jp',
     })
     assert auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',


### PR DESCRIPTION
ログイン時のOpenIdP メールアドレスのドメインチェックにて、.waseda.jpを許可するようにしました。