### PR TITLE
Feature/dynamic allowed domains

### DIFF
--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -9,15 +9,17 @@ from tornado import gen, web
 from traitlets import Unicode, Bool, List
 from .utils import normalize_quoted_printable
 
+DEFAULT_ALLOWED_PATTERNS = [r'^.*\.(ac|go)\.jp$', r'^.*\@(.+\.)?waseda\.jp$', r'^.*\@(.+\.)?hro\.or\.jp$']
 
 def check_valid_organization(headers, allowed_patterns):
     eppn = headers.get('Eppn', None)
     mail = headers.get('Mail', None)
-    print(allowed_patterns)
     if eppn is None:
         return False
     if eppn.endswith('@openidp.nii.ac.jp'):
         if mail is None:
+            return False
+        if not re.match(r'^[^\"@\s]+?@([^\"@\s]+?)+$', mail):
             return False
         for pattern in allowed_patterns:
             if re.match(pattern, mail):
@@ -99,7 +101,7 @@ class RemoteUserAuthenticator(Authenticator):
     List of allowed domains for OpenIdP
     """
     allowed_patterns = List(
-        default_value=[r'^.*\.(ac|go)\.jp$', r'^.*\@(.+\.)?waseda\.jp$'],
+        default_value=DEFAULT_ALLOWED_PATTERNS,
         config=True,
         help="""The list of domains to be allowed access from OpenIdP""")
 
@@ -171,7 +173,7 @@ class RemoteUserLocalAuthenticator(LocalAuthenticator):
         help="""Whether to allow any organizations""")
 
     allowed_patterns = List(
-        default_value=[r'^.*\.(ac|go)\.jp$', r'^.*\@(.+\.)?waseda\.jp$'],
+        default_value=DEFAULT_ALLOWED_PATTERNS,
         config=True,
         help="""The list of domains to be allowed access from OpenIdP""")
 

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -9,7 +9,7 @@ from tornado import gen, web
 from traitlets import Unicode, Bool, List
 from .utils import normalize_quoted_printable
 
-DEFAULT_ALLOWED_PATTERNS = [r'^.*\.(ac|go)\.jp$', r'^.*\@(.+\.)?waseda\.jp$', r'^.*\@(.+\.)?hro\.or\.jp$']
+DEFAULT_ALLOWED_PATTERNS = [r'^.+\.(ac|go)\.jp$', r'^.+[@.]waseda\.jp$', r'^.+[@.]hro\.or\.jp$']
 
 def check_valid_organization(headers, openidp_allow_patterns):
     eppn = headers.get('Eppn', None)
@@ -19,7 +19,7 @@ def check_valid_organization(headers, openidp_allow_patterns):
     if eppn.endswith('@openidp.nii.ac.jp'):
         if mail is None:
             return False
-        if not re.match(r'^[^\"@\s]+?@([^\"@\s]+?)+$', mail):
+        if not re.match(r'^[^\"@\s]+?@[^@]+$', mail):
             return False
         for pattern in openidp_allow_patterns:
             if re.match(pattern, mail):

--- a/jhub_remote_user_authenticator/remote_user_auth.py
+++ b/jhub_remote_user_authenticator/remote_user_auth.py
@@ -9,8 +9,6 @@ from tornado import gen, web
 from traitlets import Unicode, Bool, List
 from .utils import normalize_quoted_printable
 
-DEFAULT_ALLOWED_PATTERNS = [r'^.+\.(ac|go)\.jp$', r'^.+[@.]waseda\.jp$', r'^.+[@.]hro\.or\.jp$']
-
 def check_valid_organization(headers, openidp_allow_patterns):
     eppn = headers.get('Eppn', None)
     mail = headers.get('Mail', None)
@@ -101,7 +99,7 @@ class RemoteUserAuthenticator(Authenticator):
     List of allowed domains for OpenIdP
     """
     openidp_allow_patterns = List(
-        default_value=DEFAULT_ALLOWED_PATTERNS,
+        default_value=[],
         config=True,
         help="""The list of domains to be allowed access from OpenIdP""")
 
@@ -173,7 +171,7 @@ class RemoteUserLocalAuthenticator(LocalAuthenticator):
         help="""Whether to allow any organizations""")
 
     openidp_allow_patterns = List(
-        default_value=DEFAULT_ALLOWED_PATTERNS,
+        default_value=[],
         config=True,
         help="""The list of domains to be allowed access from OpenIdP""")
 

--- a/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
+++ b/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
@@ -49,6 +49,94 @@ def test_valid_organization(authclass):
         'Eppn': 'testtest@openidp.nii.ac.jp',
         'Mail': 'test@test.waseda.jp',
     })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test@test.waseda.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': '"dangerous-local://part////."@test.waseda.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@"dangerous---domain---".waseda.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'not@valid@test.go.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': '"dangerous-localpart"@test.go.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'sample@hro.or.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'sample@test.hro.or.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'sample@sample@test.hro.or.jp',
+    })
+
+    auth.allowed_patterns = [r'^.*\@(.+\.)?newdomain\.jp$']
+    assert not auth.check_valid_organization({})
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.co.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.com',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@go.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@ac.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.ac.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'test@test-org.ac.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test-org.go.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'test@test-org.go.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@waseda.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@newdomain.jp',
+    })
+    assert auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test.newdomain.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': 'test@test@test.newdomain.jp',
+    })
+    assert not auth.check_valid_organization({
+        'Eppn': 'testtest@openidp.nii.ac.jp',
+        'Mail': '"dangerous-local://part////."@test.newdomain.jp',
+    })
 
     auth.allow_any_organizations = True
     assert auth.check_valid_organization({})

--- a/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
+++ b/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
@@ -7,6 +7,7 @@ from jhub_remote_user_authenticator import remote_user_auth
                           remote_user_auth.RemoteUserLocalAuthenticator])
 def test_valid_organization(authclass):
     auth = authclass()
+    auth.openidp_allow_patterns = [r'^.+\.(ac|go)\.jp$', r'^.+[@.]domain1\.jp$']
     assert not auth.check_valid_organization({})
     assert not auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
@@ -43,19 +44,19 @@ def test_valid_organization(authclass):
     })
     assert auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'test@waseda.jp',
+        'Mail': 'test@domain1.jp',
     })
     assert auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'test@test.waseda.jp',
+        'Mail': 'test@test.domain1.jp',
     })
     assert not auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'test@test@test.waseda.jp',
+        'Mail': 'test@test@test.domain1.jp',
     })
     assert not auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': '"dangerous-local://part////."@test.waseda.jp',
+        'Mail': '"dangerous-local://part////."@test.domain1.jp',
     })
     assert not auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
@@ -64,18 +65,6 @@ def test_valid_organization(authclass):
     assert not auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
         'Mail': '"dangerous-localpart"@test.go.jp',
-    })
-    assert auth.check_valid_organization({
-        'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'sample@hro.or.jp',
-    })
-    assert auth.check_valid_organization({
-        'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'sample@test.hro.or.jp',
-    })
-    assert not auth.check_valid_organization({
-        'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'sample@sample@test.hro.or.jp',
     })
 
     auth.openidp_allow_patterns = [r'^.*\@(.+\.)?newdomain\.jp$']
@@ -115,7 +104,7 @@ def test_valid_organization(authclass):
     })
     assert not auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'test@waseda.jp',
+        'Mail': 'test@domain1.jp',
     })
     assert auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
@@ -171,9 +160,9 @@ def test_valid_organization(authclass):
     })
     assert auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'test@waseda.jp',
+        'Mail': 'test@domain1.jp',
     })
     assert auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'test@test.waseda.jp',
+        'Mail': 'test@test.domain1.jp',
     })

--- a/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
+++ b/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
@@ -82,7 +82,7 @@ def test_valid_organization(authclass):
         'Mail': 'sample@sample@test.hro.or.jp',
     })
 
-    auth.allowed_patterns = [r'^.*\@(.+\.)?newdomain\.jp$']
+    auth.openidp_allow_patterns = [r'^.*\@(.+\.)?newdomain\.jp$']
     assert not auth.check_valid_organization({})
     assert not auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',

--- a/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
+++ b/jhub_remote_user_authenticator/tests/test_remote_user_auth.py
@@ -59,10 +59,6 @@ def test_valid_organization(authclass):
     })
     assert not auth.check_valid_organization({
         'Eppn': 'testtest@openidp.nii.ac.jp',
-        'Mail': 'test@"dangerous---domain---".waseda.jp',
-    })
-    assert not auth.check_valid_organization({
-        'Eppn': 'testtest@openidp.nii.ac.jp',
         'Mail': 'not@valid@test.go.jp',
     })
     assert not auth.check_valid_organization({


### PR DESCRIPTION
チケット https://redmine.devops.rcos.nii.ac.jp/issues/31451 に関して、
`hro.or.jp` ドメインを許可するよう変更を行いました。
さらに、allowed_patterns というコンフィグを追加し、許可されるパターンを外から設定できるようにしてあります。

また、以下のご要望に関しては waseda.jp などの特定のパターンに限らず常に除外すべきかと思ったため、個別のパターンのチェックを行う前に、`r'^[^\"@\s]+?@([^\"@\s]+?)+$'` という正規表現でチェックを行っています。

> 修正前の正規表現は、「.」が最長マッチになっているので、変なアドレス（アットマークが2個以上ある、ダブルクオートで囲んで任意の文字を含む、など）にもマッチしてしまいます。
> 到達性はOpenIdP側で確認済みなので厳密にチェックする必要はありませんが、Jupyter側の誤動作防止という観点から、あまりに変なアドレスは弾いておきましょう。